### PR TITLE
DVY-25 Calculate tip before adding tax

### DIFF
--- a/DVY/TaxTipPage.swift
+++ b/DVY/TaxTipPage.swift
@@ -217,7 +217,7 @@ struct TaxTipPage: View {
     }
     
     func calculateCurrentTip() -> CurrencyObject {
-        return CurrencyObject(price: (subtotal + tax.price) * getCurrentTipDecimal())
+        return CurrencyObject(price: subtotal * getCurrentTipDecimal())
     }
     
     func calculateCurrentTotal() -> CurrencyObject {
@@ -225,7 +225,7 @@ struct TaxTipPage: View {
             return CurrencyObject(price: (subtotal + tax.price + customTip.price))
         }
         
-        return CurrencyObject(price: (subtotal + tax.price) * (1 + getCurrentTipDecimal()))
+        return CurrencyObject(price: subtotal + tax.price + calculateCurrentTip().price)
     }
     
     func saveCustomTip() {


### PR DESCRIPTION
Tip percentages should be calculated before factoring in tax. This pull request makes that adjustment to the tip calculation method and to the total calculation method.