### PR TITLE
Fix #71 and added a guard statement to prevent crash on startup

### DIFF
--- a/DVY/AssignItems/FriendItemListModal.swift
+++ b/DVY/AssignItems/FriendItemListModal.swift
@@ -82,7 +82,7 @@ struct FriendItemListModal: View {
     }
     
     func deleteItem(itemIndex: Int) {
-        items.append(friends[friendIndex!].items[itemIndex])
+        items.insert(friends[friendIndex!].items[itemIndex], at: 0)
         friends[friendIndex!].items.remove(at: itemIndex)
         
         if friends[friendIndex!].items.count == 0 {

--- a/DVY/ContentView.swift
+++ b/DVY/ContentView.swift
@@ -127,7 +127,7 @@ struct ContentView: View {
                 fatalError(error.localizedDescription)
             case .success(let friends):
                 store.previouslyAddedFriends = friends.sorted(by: { $0.useCount > $1.useCount })
-                
+                if store.previouslyAddedFriends.count < 1 { return }
                 for i in 0...store.previouslyAddedFriends.count - 1 {
                     store.previouslyAddedFriends[i].isVisible = true
                 }


### PR DESCRIPTION
Guard statement added in ContentView.swift to prevent the app from crashing if no friends have been stored.
Fixed Issue #71 (when un-assigning an item from a friend it is now pushed to the front of the list)